### PR TITLE
removed gzip compression as its pointless

### DIFF
--- a/bigplanet/bp_extract.py
+++ b/bigplanet/bp_extract.py
@@ -360,7 +360,7 @@ def ArchiveToFiltered(inputfile, columns, exportfile):
 
         with h5py.File(exportfile, "a") as f_dest:
             f_dest.create_dataset(
-                i, data=export[i], compression='gzip')
+                i, data=export[i])
             f_dest[i].attrs['Units'] = units[i]
 
 

--- a/bigplanet/bp_process.py
+++ b/bigplanet/bp_process.py
@@ -498,7 +498,6 @@ def DictToBP(data, vplanet_help, h5_file, verbose=False, group_name="", archive=
             print("Value:", v_value)
             print()
 
-        h5_file.create_dataset(dataset_name, data=v_value,
-                               compression='gzip')
+        h5_file.create_dataset(dataset_name, data=v_value)
 
         h5_file[dataset_name].attrs['Units'] = v_attr


### PR DESCRIPTION
it turns out with the most recent version of h5py, that using compression and fletcher32 with variable-length sequences (such as strings) will print an error since those filters cannot be applied to it 