### PR TITLE
Edited create_dataset arguments to handle strings in data

### DIFF
--- a/bigplanet/bp_process.py
+++ b/bigplanet/bp_process.py
@@ -498,6 +498,6 @@ def DictToBP(data, vplanet_help, h5_file, verbose=False, group_name="", archive=
             print("Value:", v_value)
             print()
 
-        h5_file.create_dataset(dataset_name, data=v_value)
+        h5_file.create_dataset(dataset_name, data=np.array([v_value], dtype=tp))
 
         h5_file[dataset_name].attrs['Units'] = v_attr


### PR DESCRIPTION
Change here reflects a prior version of bigplanet. I'm not quite sure why this is needed, but without these arguments the HDF5 file cannot be created because it doesn't like to read strings.